### PR TITLE
fix(mypy): パターンマッチによるimportエラー抑制設定に変更（今後の問題追加対応）

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,13 +164,11 @@ pretty = true
 
 # Ignore missing imports for problem modules in tests
 [[tool.mypy.overrides]]
-module = [
-    "problem_001",
-    "problem_002",
-    "problem_003",
-    "problem_004",
-    "problem_005"
-]
+module = "problems.problem_*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tests.problems.test_problem_*"
 ignore_missing_imports = true
 
 # Pytest configuration


### PR DESCRIPTION
## 概要
- mypyの設定をパターンマッチ形式に修正し、今後の問題追加時にもimportエラーが発生しないようにしました。
- module = 'problems.problem_*', 'tests.problems.test_problem_*' で自動的にignore_missing_importsが適用されます。

## 背景
- Project Eulerの新規問題追加時、毎回pyproject.tomlを編集する手間を省くための改善です。

## 影響範囲
- 型チェックの柔軟性向上
- 今後の問題追加・テスト追加時の運用効率化

ご確認よろしくお願いします。