### PR TITLE
Solve Problem 032: Pandigital products

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -495,3 +495,9 @@ Project Euler公式サイトで確認してください。
 - **解答:** [隠匿]
 - **検証:** ✓
 ```
+
+## Git and PR Guidelines
+
+### PR Submission Guidelines
+- **PR発行時のチェックリスト**:
+  - PRを発行するときは、pushするブランチがあっているかどうか確認して

--- a/docs/solutions/solution_032.md
+++ b/docs/solutions/solution_032.md
@@ -1,0 +1,199 @@
+# Problem 032: Pandigital products
+
+## 問題
+
+We shall say that an n-digit number is pandigital if it makes use of all the digits 1 to n exactly once; for example, the 5-digit number, 15234, is 1 through 5 pandigital.
+
+The product 7254 is unusual, as the identity, 39 × 186 = 7254, containing multiplicand, multiplier, and product is 1 through 9 pandigital.
+
+Find the sum of all products whose multiplicand/multiplier/product identity can be written as a 1 through 9 pandigital.
+
+**1からnまでの数字を正確に一度ずつ使用する数字をnパンデジタル数と呼びます。例えば、5桁の数字15234は1から5のパンデジタル数です。**
+
+**積7254は特殊で、恒等式39 × 186 = 7254において、乗数、被乗数、積が1から9のパンデジタル数になっています。**
+
+**乗数/被乗数/積の恒等式が1から9のパンデジタル数として書けるすべての積の合計を求めてください。**
+
+## 解答
+
+Project Euler公式サイトで確認してください。
+
+## 解法
+
+### 1. 素直な解法（総当たり）
+
+全ての可能な乗数と被乗数の組み合わせを試行し、パンデジタル条件を満たすかどうかを確認します。
+
+```python
+def solve_naive() -> int:
+    pandigital_products = set()
+    
+    # 1桁 × 4桁 = 4桁のケース
+    for a in range(1, 10):
+        for bcde in range(1000, 10000):
+            product = a * bcde
+            if product >= 10000:
+                break
+            combined = str(a) + str(bcde) + str(product)
+            if is_pandigital_1_to_9(combined):
+                pandigital_products.add(product)
+    
+    # 2桁 × 3桁 = 4桁のケース
+    for ab in range(10, 100):
+        for cde in range(100, 1000):
+            product = ab * cde
+            if product >= 10000:
+                break
+            combined = str(ab) + str(cde) + str(product)
+            if is_pandigital_1_to_9(combined):
+                pandigital_products.add(product)
+    
+    return sum(pandigital_products)
+```
+
+**時間計算量**: O(n²) - nは探索範囲
+**空間計算量**: O(k) - kは見つかった積の数
+
+### 2. 最適化解法（効率的探索）
+
+桁数の制約を利用して探索範囲を狭めます。
+
+```python
+def solve_optimized() -> int:
+    pandigital_products = set()
+    
+    # 1桁 × 4桁 = 4桁のケース
+    for multiplicand in range(1, 10):
+        min_multiplier = 1000
+        max_multiplier = min(9999, 9999 // multiplicand)
+        
+        for multiplier in range(min_multiplier, max_multiplier + 1):
+            product = multiplicand * multiplier
+            if product < 1000 or product >= 10000:
+                continue
+            combined = str(multiplicand) + str(multiplier) + str(product)
+            if is_pandigital_1_to_9(combined):
+                pandigital_products.add(product)
+    
+    # 2桁 × 3桁 = 4桁のケース
+    for multiplicand in range(10, 100):
+        min_multiplier = max(100, 1000 // multiplicand)
+        max_multiplier = min(999, 9999 // multiplicand)
+        
+        if min_multiplier > max_multiplier:
+            continue
+        for multiplier in range(min_multiplier, max_multiplier + 1):
+            product = multiplicand * multiplier
+            if product < 1000 or product >= 10000:
+                continue
+            combined = str(multiplicand) + str(multiplier) + str(product)
+            if is_pandigital_1_to_9(combined):
+                pandigital_products.add(product)
+    
+    return sum(pandigital_products)
+```
+
+**時間計算量**: O(n) - より狭い範囲での探索
+**空間計算量**: O(k) - kは見つかった積の数
+
+### 3. 数学的解法（パターン分析）
+
+9桁のパンデジタル数の制約から可能な乗算パターンを分析します。
+
+```python
+def solve_mathematical() -> int:
+    # 9桁のパンデジタル数では、可能な乗算パターンは限定される
+    # a × bcde = fghi (1 + 4 + 4 = 9)
+    # ab × cde = fghi (2 + 3 + 4 = 9)
+    
+    def find_pandigital_products_pattern_1() -> set[int]:
+        """1桁 × 4桁 = 4桁パターン"""
+        # より効率的な範囲計算で実装
+    
+    def find_pandigital_products_pattern_2() -> set[int]:
+        """2桁 × 3桁 = 4桁パターン"""
+        # より効率的な範囲計算で実装
+    
+    # 両パターンの結果を結合
+    pandigital_products = set()
+    pandigital_products.update(find_pandigital_products_pattern_1())
+    pandigital_products.update(find_pandigital_products_pattern_2())
+    
+    return sum(pandigital_products)
+```
+
+**時間計算量**: O(n) - より効率的な探索
+**空間計算量**: O(k) - kは見つかった積の数
+
+## 数学的背景
+
+### パンデジタル数の性質
+
+1から9のパンデジタル数は、1,2,3,4,5,6,7,8,9の数字を正確に一度ずつ使用する9桁の数字です。
+
+### 桁数の制約分析
+
+乗数 × 被乗数 = 積の桁数の組み合わせで、合計が9桁になるパターンは限定されます：
+
+- **1桁 × 4桁 = 4桁**: 1 + 4 + 4 = 9桁 ✓
+- **2桁 × 3桁 = 4桁**: 2 + 3 + 4 = 9桁 ✓
+- **1桁 × 3桁 = 5桁**: 1 + 3 + 5 = 9桁（範囲外）
+- **その他の組み合わせ**: 9桁にならない
+
+### パンデジタル積の例
+
+問題文で示されている例：
+- 39 × 186 = 7254
+- 組み合わせ: "391867254"
+- すべての桁（1-9）が正確に一度ずつ使用されている
+
+その他の例：
+- 4 × 1738 = 6952 → "417386952"
+- 4 × 1963 = 7852 → "419637852"
+
+## 検証
+
+### テストケース
+- **パンデジタル判定**: "123456789" → True
+- **重複検出**: "123456788" → False
+- **桁数不足**: "12345679" → False
+- **例題検証**: "391867254" → True
+
+### 解答
+Project Euler公式サイトで確認してください。
+
+### 検証結果
+- **素直な解法**: [隠匿]
+- **最適化解法**: [隠匿]
+- **数学的解法**: [隠匿]
+- **一致確認**: ✓
+
+## パフォーマンス比較
+
+実行時間の比較（参考値）：
+- **素直な解法**: ~0.027秒
+- **最適化解法**: ~0.028秒
+- **数学的解法**: ~0.027秒
+
+すべての解法が高速で実行され、大きな性能差はありませんが、最適化により探索範囲の削減が実現されています。
+
+## 最適化のポイント
+
+1. **桁数制約の活用**: 9桁の制約から可能なパターンを限定
+2. **探索範囲の計算**: 乗数の範囲を事前に計算して無駄な計算を回避
+3. **重複排除**: setを使用してユニークな積のみを保持
+4. **早期終了**: 積が範囲外になった場合の即座の終了
+
+## 学習ポイント
+
+1. **パンデジタル数**: 数字の組み合わせに関する数学的性質の理解
+2. **組み合わせ論**: 限定された数字セットでの数値構成
+3. **効率的探索**: 制約条件を活用した探索空間の削減
+4. **パターン認識**: 数学的規則性からのアルゴリズム最適化
+5. **集合操作**: Pythonのsetを使った重複排除と和集合操作
+
+## 参考
+
+- [Project Euler Problem 032](https://projecteuler.net/problem=32)
+- [Pandigital number - Wikipedia](https://en.wikipedia.org/wiki/Pandigital_number)
+- [Permutations and Combinations](https://en.wikipedia.org/wiki/Permutation)

--- a/problems/problem_032.py
+++ b/problems/problem_032.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+Problem 032: Pandigital products
+
+We shall say that an n-digit number is pandigital if it makes use of all the
+digits 1 to n exactly once; for example, the 5-digit number, 15234, is 1 through 5 pandigital.
+
+The product 7254 is unusual, as the identity, 39 × 186 = 7254, containing multiplicand,
+multiplier, and product is 1 through 9 pandigital.
+
+Find the sum of all products whose multiplicand/multiplier/product identity can be written
+as a 1 through 9 pandigital.
+
+Answer: 45228
+"""
+
+
+def is_pandigital_1_to_9(digits_str: str) -> bool:
+    """
+    1から9のパンデジタル数かどうか判定
+    時間計算量: O(1) - 最大9文字の固定長
+    空間計算量: O(1)
+    """
+    if len(digits_str) != 9:
+        return False
+
+    digit_set = set(digits_str)
+    return digit_set == {"1", "2", "3", "4", "5", "6", "7", "8", "9"}
+
+
+def solve_naive() -> int:
+    """
+    素直な解法: 全ての可能な組み合わせを総当たりで検証
+    時間計算量: O(n^2) - nは探索範囲
+    空間計算量: O(k) - kは見つかった積の数
+    """
+    pandigital_products = set()
+
+    # 全ての可能な乗数と被乗数の組み合わせを試行
+    # 1桁 × 4桁 = 4桁のケース: a × bcde = fghi
+    for a in range(1, 10):
+        for bcde in range(1000, 10000):
+            product = a * bcde
+            if product >= 10000:  # 5桁以上になったら無意味
+                break
+
+            # パンデジタル判定
+            combined = str(a) + str(bcde) + str(product)
+            if is_pandigital_1_to_9(combined):
+                pandigital_products.add(product)
+
+    # 2桁 × 3桁 = 4桁のケース: ab × cde = fghi
+    for ab in range(10, 100):
+        for cde in range(100, 1000):
+            product = ab * cde
+            if product >= 10000:  # 5桁以上になったら無意味
+                break
+
+            # パンデジタル判定
+            combined = str(ab) + str(cde) + str(product)
+            if is_pandigital_1_to_9(combined):
+                pandigital_products.add(product)
+
+    return sum(pandigital_products)
+
+
+def solve_optimized() -> int:
+    """
+    最適化解法: 桁数の制約を利用した効率的な探索
+    時間計算量: O(n) - より狭い範囲での探索
+    空間計算量: O(k) - kは見つかった積の数
+    """
+    pandigital_products = set()
+
+    # 数学的分析:
+    # 1 × 4桁 = 4桁: 1 + 4 + 4 = 9桁 ✓
+    # 2桁 × 3桁 = 4桁: 2 + 3 + 4 = 9桁 ✓
+    # その他の組み合わせは9桁にならない
+
+    # 1桁 × 4桁 = 4桁のケース
+    for multiplicand in range(1, 10):
+        # 4桁の乗数の範囲を計算
+        min_multiplier = 1000
+        max_multiplier = min(9999, 9999 // multiplicand)
+
+        for multiplier in range(min_multiplier, max_multiplier + 1):
+            product = multiplicand * multiplier
+
+            # 積が4桁でない場合はスキップ
+            if product < 1000 or product >= 10000:
+                continue
+
+            # パンデジタル判定
+            combined = str(multiplicand) + str(multiplier) + str(product)
+            if is_pandigital_1_to_9(combined):
+                pandigital_products.add(product)
+
+    # 2桁 × 3桁 = 4桁のケース
+    for multiplicand in range(10, 100):
+        # 3桁の乗数の範囲を計算
+        min_multiplier = max(100, 1000 // multiplicand)
+        max_multiplier = min(999, 9999 // multiplicand)
+
+        if min_multiplier > max_multiplier:
+            continue
+
+        for multiplier in range(min_multiplier, max_multiplier + 1):
+            product = multiplicand * multiplier
+
+            # 積が4桁でない場合はスキップ
+            if product < 1000 or product >= 10000:
+                continue
+
+            # パンデジタル判定
+            combined = str(multiplicand) + str(multiplier) + str(product)
+            if is_pandigital_1_to_9(combined):
+                pandigital_products.add(product)
+
+    return sum(pandigital_products)
+
+
+def solve_mathematical() -> int:
+    """
+    数学的解法: パンデジタル条件を満たす乗数の桁数パターンの分析
+    時間計算量: O(n) - より効率的な探索
+    空間計算量: O(k) - kは見つかった積の数
+    """
+    pandigital_products = set()
+
+    # 数学的洞察:
+    # 9桁のパンデジタル数では、可能な乗算パターンは限定される
+    # a × bcde = fghi (1 + 4 + 4 = 9)
+    # ab × cde = fghi (2 + 3 + 4 = 9)
+
+    def find_pandigital_products_pattern_1() -> set[int]:
+        """1桁 × 4桁 = 4桁パターン"""
+        products = set()
+
+        # 1桁の乗数は1-9
+        for a in range(1, 10):
+
+            # 4桁数の最小値と最大値を計算
+            min_4digit = 1000
+            max_4digit = 9999
+
+            # より効率的な範囲計算
+            start = max(min_4digit, 1000 // a if a != 0 else min_4digit)
+            end = min(max_4digit, 9999 // a if a != 0 else max_4digit)
+
+            for bcde in range(start, end + 1):
+                product = a * bcde
+                if 1000 <= product <= 9999:
+                    combined = str(a) + str(bcde) + str(product)
+                    if is_pandigital_1_to_9(combined):
+                        products.add(product)
+
+        return products
+
+    def find_pandigital_products_pattern_2() -> set[int]:
+        """2桁 × 3桁 = 4桁パターン"""
+        products = set()
+
+        # 2桁の乗数: 10-99
+        for ab in range(10, 100):
+            # 3桁の乗数の効率的な範囲計算
+            start = max(100, 1000 // ab)
+            end = min(999, 9999 // ab)
+
+            if start <= end:
+                for cde in range(start, end + 1):
+                    product = ab * cde
+                    if 1000 <= product <= 9999:
+                        combined = str(ab) + str(cde) + str(product)
+                        if is_pandigital_1_to_9(combined):
+                            products.add(product)
+
+        return products
+
+    # 両パターンの結果を結合
+    pandigital_products.update(find_pandigital_products_pattern_1())
+    pandigital_products.update(find_pandigital_products_pattern_2())
+
+    return sum(pandigital_products)
+

--- a/problems/runners/problem_032_runner.py
+++ b/problems/runners/problem_032_runner.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Problem 032 Runner: Pandigital products
+
+実行・表示・パフォーマンス測定を担当
+"""
+
+from problems.problem_032 import (
+    is_pandigital_1_to_9,
+    solve_mathematical,
+    solve_naive,
+    solve_optimized,
+)
+from problems.utils.display import print_final_answer, print_performance_comparison
+from problems.utils.performance import compare_performance
+
+
+def test_solutions() -> bool:
+    """テストケースで解答を検証"""
+    print("=== パンデジタル判定テスト ===")
+
+    # パンデジタル判定のテストケース
+    test_cases = [
+        ("123456789", True),   # 正常な1-9パンデジタル
+        ("987654321", True),   # 逆順の1-9パンデジタル
+        ("123456788", False),  # 8が重複
+        ("12345679", False),   # 8文字（不足）
+        ("1234567890", False), # 10文字（過多）
+        ("023456789", False),  # 0を含む
+        ("391867254", True),   # 例題の組み合わせ
+    ]
+
+    print("パンデジタル判定:")
+    for digits, expected in test_cases:
+        result = is_pandigital_1_to_9(digits)
+        status = "✓" if result == expected else "✗"
+        print(f"  {digits}: {result} {status}")
+
+    print("\n=== 解法一致確認 ===")
+
+    # 全ての解法が同じ結果を返すことを確認
+    result_naive = solve_naive()
+    result_optimized = solve_optimized()
+    result_mathematical = solve_mathematical()
+
+    print(f"素直な解法: {result_naive}")
+    print(f"最適化解法: {result_optimized}")
+    print(f"数学的解法: {result_mathematical}")
+
+    if result_naive == result_optimized == result_mathematical:
+        print("✓ 全ての解法が一致しました")
+        return True
+    print("✗ 解法間で結果が異なります")
+    return False
+
+
+def demonstrate_pandigital_examples() -> None:
+    """パンデジタル積の例を表示"""
+    print("\n=== パンデジタル積の例 ===")
+
+    # 既知の例
+    examples = [
+        (39, 186, 7254),   # 39 × 186 = 7254
+        (4, 1738, 6952),   # 4 × 1738 = 6952
+        (4, 1963, 7852),   # 4 × 1963 = 7852
+    ]
+
+    for multiplicand, multiplier, expected_product in examples:
+        product = multiplicand * multiplier
+        combined = str(multiplicand) + str(multiplier) + str(product)
+        is_pandigital = is_pandigital_1_to_9(combined)
+
+        print(f"  {multiplicand} × {multiplier} = {product}")
+        print(f"    組み合わせ: {combined}")
+        print(f"    パンデジタル: {'✓' if is_pandigital else '✗'}")
+        print(f"    検証: {'✓' if product == expected_product else '✗'}")
+        print()
+
+
+def run_problem() -> None:
+    """問題の実行"""
+    print("Problem 032: Pandigital products")
+    print("=" * 50)
+
+    # テストケース実行
+    if not test_solutions():
+        print("エラー: テストケースが失敗しました")
+        return
+
+    # パンデジタル積の例を表示
+    demonstrate_pandigital_examples()
+
+    print("=== 本問題の解答 ===")
+
+    # パフォーマンス比較と結果表示
+    solutions = [
+        ("素直な解法", solve_naive),
+        ("最適化解法", solve_optimized),
+        ("数学的解法", solve_mathematical),
+    ]
+
+    results = compare_performance(solutions)
+    print_performance_comparison(results)
+
+    # Get the result from the first solution
+    first_solution_name = next(iter(results.keys()))
+    answer = results[first_solution_name]["result"]
+    print_final_answer(answer)
+
+
+if __name__ == "__main__":
+    run_problem()

--- a/tests/problems/test_problem_032.py
+++ b/tests/problems/test_problem_032.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Test for Problem 032: Pandigital products
+"""
+
+import pytest
+
+from problems.problem_032 import (
+    is_pandigital_1_to_9,
+    solve_mathematical,
+    solve_naive,
+    solve_optimized,
+)
+
+
+class TestProblem032:
+    """Problem 032のテストクラス"""
+
+    def test_is_pandigital_1_to_9(self):
+        """パンデジタル判定関数のテスト"""
+        # 正常な1-9パンデジタル
+        assert is_pandigital_1_to_9("123456789") is True
+        assert is_pandigital_1_to_9("987654321") is True
+        assert is_pandigital_1_to_9("391867254") is True  # 39 × 186 × 7254
+
+        # 異常ケース
+        assert is_pandigital_1_to_9("123456788") is False  # 8が重複
+        assert is_pandigital_1_to_9("12345679") is False   # 8文字（不足）
+        assert is_pandigital_1_to_9("1234567890") is False # 10文字（過多）
+        assert is_pandigital_1_to_9("023456789") is False  # 0を含む
+        assert is_pandigital_1_to_9("123456780") is False  # 0を含む、9がない
+
+    def test_known_pandigital_products(self):
+        """既知のパンデジタル積の例をテスト"""
+        # 例題で示されている組み合わせ
+        examples = [
+            (39, 186, 7254),   # 39 × 186 = 7254
+            (4, 1738, 6952),   # 4 × 1738 = 6952 (推定)
+            (4, 1963, 7852),   # 4 × 1963 = 7852 (推定)
+        ]
+
+        for multiplicand, multiplier, expected_product in examples:
+            # 乗算が正しいことを確認
+            assert multiplicand * multiplier == expected_product
+
+            # パンデジタル条件を満たすことを確認
+            combined = str(multiplicand) + str(multiplier) + str(expected_product)
+            if len(combined) == 9:  # 9桁の場合のみテスト
+                assert is_pandigital_1_to_9(combined)
+
+    def test_solve_naive(self):
+        """素直な解法のテスト"""
+        result = solve_naive()
+        assert isinstance(result, int)
+        assert result > 0
+        # 期待される解答の範囲をテスト（具体的な値は隠匿）
+        assert 40000 <= result <= 50000
+
+    def test_solve_optimized(self):
+        """最適化解法のテスト"""
+        result = solve_optimized()
+        assert isinstance(result, int)
+        assert result > 0
+        # 期待される解答の範囲をテスト
+        assert 40000 <= result <= 50000
+
+    def test_solve_mathematical(self):
+        """数学的解法のテスト"""
+        result = solve_mathematical()
+        assert isinstance(result, int)
+        assert result > 0
+        # 期待される解答の範囲をテスト
+        assert 40000 <= result <= 50000
+
+    def test_all_solutions_agree(self):
+        """すべての解法が同じ結果を返すことを確認"""
+        naive_result = solve_naive()
+        optimized_result = solve_optimized()
+        mathematical_result = solve_mathematical()
+
+        assert naive_result == optimized_result == mathematical_result
+
+    @pytest.mark.slow
+    def test_performance_comparison(self):
+        """パフォーマンス比較のテスト（時間測定）"""
+        import time
+
+        # 素直な解法
+        start_time = time.time()
+        result_naive = solve_naive()
+        naive_time = time.time() - start_time
+
+        # 最適化解法
+        start_time = time.time()
+        result_optimized = solve_optimized()
+        optimized_time = time.time() - start_time
+
+        # 数学的解法
+        start_time = time.time()
+        result_mathematical = solve_mathematical()
+        mathematical_time = time.time() - start_time
+
+        # 結果が一致することを確認
+        assert result_naive == result_optimized == result_mathematical
+
+        # 最適化解法の方が高速であることを期待（絶対的ではない）
+        print(f"素直な解法: {naive_time:.6f}秒")
+        print(f"最適化解法: {optimized_time:.6f}秒")
+        print(f"数学的解法: {mathematical_time:.6f}秒")
+
+        # 全ての解法が妥当な時間内で実行されることを確認
+        assert naive_time < 10.0  # 10秒以内
+        assert optimized_time < 5.0  # 5秒以内
+        assert mathematical_time < 5.0  # 5秒以内
+
+    def test_edge_cases(self):
+        """エッジケースのテスト"""
+        # パンデジタル判定のエッジケース
+        assert is_pandigital_1_to_9("") is False
+        assert is_pandigital_1_to_9("1") is False
+        assert is_pandigital_1_to_9("123456789123456789") is False
+
+        # 重複数字
+        assert is_pandigital_1_to_9("111111111") is False
+        assert is_pandigital_1_to_9("123123123") is False
+
+    def test_digit_patterns(self):
+        """桁数パターンのテスト"""
+        # 1桁 × 4桁 = 4桁パターンの検証
+        # 例: 4 × 1738 = 6952 → "417386952"
+        combined_1 = "417386952"
+        assert len(combined_1) == 9
+        assert is_pandigital_1_to_9(combined_1)
+
+        # 2桁 × 3桁 = 4桁パターンの検証
+        # 例: 39 × 186 = 7254 → "391867254"
+        combined_2 = "391867254"
+        assert len(combined_2) == 9
+        assert is_pandigital_1_to_9(combined_2)
+


### PR DESCRIPTION
## Problem 032: Pandigital products

### 解答: 45228

### 実装内容
パンデジタル積を見つける問題を3つのアプローチで解決しました：

1. **素直な解法**: 全ての可能な組み合わせを総当たりで検証
2. **最適化解法**: 桁数の制約を利用した効率的な探索
3. **数学的解法**: パンデジタル条件を満たす乗数の桁数パターンの分析

### 数学的洞察
- 1から9のパンデジタル数では、可能な乗算パターンは限定される
- 1桁 × 4桁 = 4桁: 1 + 4 + 4 = 9桁 ✓
- 2桁 × 3桁 = 4桁: 2 + 3 + 4 = 9桁 ✓
- その他の組み合わせは9桁にならない

### ファイル
- `problems/problem_032.py` - 純粋なアルゴリズム実装
- `problems/runners/problem_032_runner.py` - 実行とパフォーマンス測定
- `tests/problems/test_problem_032.py` - 包括的なテスト
- `docs/solutions/solution_032.md` - 詳細な解答説明

### 特徴
- **リファクタ構造**: アルゴリズムと実行コードの分離
- **共通ユーティリティ**: 統一されたパフォーマンス測定と表示
- **包括的テスト**: 単体テスト、エッジケース、パフォーマンステスト
- **詳細ドキュメント**: 数学的背景と学習ポイントを含む

### 検証
- ✓ 全ての解法が同じ結果（45228）を返すことを確認
- ✓ 既知のパンデジタル積（39 × 186 = 7254等）の検証
- ✓ パンデジタル判定関数の包括的テスト
- ✓ パフォーマンステスト（全解法が5秒以内で実行）

### 学習ポイント
- パンデジタル数の性質と制約条件の活用
- 組み合わせ論的アプローチによる探索空間の削減
- 効率的なアルゴリズム設計と最適化技法

Closes #97

🤖 Generated with [Claude Code](https://claude.ai/code)