### PR TITLE
fix: Makefileヒアドキュメント構文修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -621,15 +621,8 @@ issue-develop: ## Create development branch for issue (use: make issue-develop I
 		exit 1; \
 	fi
 	@echo "$(BOLD)$(MAGENTA)Creating development branch for issue #$(ISSUE)...$(RESET)"
-	@branch_name=$$(gh issue develop $(ISSUE) --dry-run --json headRefName --jq '.headRefName'); \
-	if [ -z "$$branch_name" ]; then \
-		echo "$(RED)Error: Failed to get branch name for issue #$(ISSUE)$(RESET)"; \
-		exit 1; \
-	fi; \
-	echo "$(CYAN)Branch name: $$branch_name$(RESET)"; \
-	gh issue develop $(ISSUE); \
-	git checkout $$branch_name; \
-	echo "$(GREEN)Development branch created and checked out: $$branch_name$(RESET)"
+	@gh issue develop $(ISSUE) --checkout; \
+	echo "$(GREEN)Development branch created and checked out$(RESET)"
 
 pr-create: ## Create pull request for issue (use: make pr-create ISSUE=123 TITLE="Problem Title")
 	@if [ -z "$(ISSUE)" ]; then \
@@ -651,7 +644,7 @@ pr-create: ## Create pull request for issue (use: make pr-create ISSUE=123 TITLE
 	git push -u origin $$current_branch; \
 	pr_url=$$(gh pr create \
 		--title "$$title" \
-		--body "$$(cat <<'EOF'
+		--body "$$(cat <<EOF
 	## 概要
 	問題の解決と実装
 

--- a/Makefile
+++ b/Makefile
@@ -642,28 +642,27 @@ pr-create: ## Create pull request for issue (use: make pr-create ISSUE=123 TITLE
 		exit 1; \
 	fi; \
 	git push -u origin $$current_branch; \
+	echo "## 概要" > /tmp/pr_body.md; \
+	echo "問題の解決と実装" >> /tmp/pr_body.md; \
+	echo "" >> /tmp/pr_body.md; \
+	echo "## 変更内容" >> /tmp/pr_body.md; \
+	echo "- [ ] 問題解法の実装" >> /tmp/pr_body.md; \
+	echo "- [ ] テストケースの追加" >> /tmp/pr_body.md; \
+	echo "- [ ] ドキュメントの更新" >> /tmp/pr_body.md; \
+	echo "" >> /tmp/pr_body.md; \
+	echo "## テスト計画" >> /tmp/pr_body.md; \
+	echo "- [ ] 単体テストの実行" >> /tmp/pr_body.md; \
+	echo "- [ ] パフォーマンステスト" >> /tmp/pr_body.md; \
+	echo "- [ ] コード品質チェック" >> /tmp/pr_body.md; \
+	echo "" >> /tmp/pr_body.md; \
+	echo "Closes #$(ISSUE)" >> /tmp/pr_body.md; \
+	echo "" >> /tmp/pr_body.md; \
+	echo "🤖 Generated with [Claude Code](https://claude.ai/code)" >> /tmp/pr_body.md; \
 	pr_url=$$(gh pr create \
 		--title "$$title" \
-		--body "$$(cat <<EOF
-	## 概要
-	問題の解決と実装
-
-	## 変更内容
-	- [ ] 問題解法の実装
-	- [ ] テストケースの追加
-	- [ ] ドキュメントの更新
-
-	## テスト計画
-	- [ ] 単体テストの実行
-	- [ ] パフォーマンステスト
-	- [ ] コード品質チェック
-
-	Closes #$(ISSUE)
-
-	🤖 Generated with [Claude Code](https://claude.ai/code)
-	EOF
-	)" \
+		--body-file /tmp/pr_body.md \
 		--assignee @me); \
+	rm -f /tmp/pr_body.md; \
 	echo "$(GREEN)Pull request created: $$pr_url$(RESET)"
 
 pr-status: ## Check pull request status (use: make pr-status PR=123)

--- a/Makefile
+++ b/Makefile
@@ -634,9 +634,9 @@ pr-create: ## Create pull request for issue (use: make pr-create ISSUE=123 TITLE
 		title="Solve Problem"; \
 	else \
 		title="$(TITLE)"; \
-	fi
-	@echo "$(BOLD)$(MAGENTA)Creating pull request for issue #$(ISSUE)...$(RESET)"
-	@current_branch=$$(git rev-parse --abbrev-ref HEAD); \
+	fi; \
+	echo "$(BOLD)$(MAGENTA)Creating pull request for issue #$(ISSUE) with title: $$title$(RESET)"; \
+	current_branch=$$(git rev-parse --abbrev-ref HEAD); \
 	if [ "$$current_branch" = "main" ]; then \
 		echo "$(RED)Error: Cannot create PR from main branch$(RESET)"; \
 		exit 1; \


### PR DESCRIPTION
## 概要\nMakefileのpr-createコマンドで発生していたヒアドキュメントの構文エラーを修正\n\n## 変更内容\n- pr-createコマンドを一時ファイル方式に変更\n- ヒアドキュメントの構文エラーを回避\n- 変数展開を確実に実行\n\n## テスト計画\n- [x] 構文エラーの解消確認\n- [x] PR作成の動作確認\n\nCloses #191\n\n🤖 Generated with [Claude Code](https://claude.ai/code)