### PR TITLE
Fix make issue-develop command: Remove unsupported --dry-run flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -638,15 +638,9 @@ issue-develop: ## Create development branch for issue (use: make issue-develop I
 		exit 1; \
 	fi
 	@echo "$(BOLD)$(MAGENTA)Creating development branch for issue #$(ISSUE)...$(RESET)"
-	@branch_name=$$(gh issue develop $(ISSUE) --dry-run --json headRefName --jq '.headRefName'); \
-	if [ -z "$$branch_name" ]; then \
-		echo "$(RED)Error: Failed to get branch name for issue #$(ISSUE)$(RESET)"; \
-		exit 1; \
-	fi; \
-	echo "$(CYAN)Branch name: $$branch_name$(RESET)"; \
-	gh issue develop $(ISSUE); \
-	git checkout $$branch_name; \
-	echo "$(GREEN)Development branch created and checked out: $$branch_name$(RESET)"
+	@gh issue develop $(ISSUE) --checkout; \
+	current_branch=$$(git rev-parse --abbrev-ref HEAD); \
+	echo "$(GREEN)Development branch created and checked out: $$current_branch$(RESET)"
 
 pr-create: ## Create pull request for issue (use: make pr-create ISSUE=123 TITLE="Problem Title")
 	@if [ -z "$(ISSUE)" ]; then \


### PR DESCRIPTION
## Problem
The `make issue-develop ISSUE=123` command was failing with error:
```
Error: unknown flag: --dry-run
Usage:  gh issue develop {<number>  < /dev/null |  <url>} [flags]
```

## Root Cause  
The Makefile was using the `--dry-run` flag with `gh issue develop`, but this flag is not supported by GitHub CLI's issue develop command.

## Solution
- ✅ Remove the unsupported `--dry-run` flag
- ✅ Simplify logic using `--checkout` flag to create and checkout branch in one step
- ✅ Remove unnecessary branch name pre-fetching logic  
- ✅ Use `git rev-parse --abbrev-ref HEAD` to get current branch name after checkout

## Changes Made
### Before (Broken)
```makefile
@branch_name=$$(gh issue develop $(ISSUE) --dry-run --json headRefName --jq '.headRefName'); \
if [ -z "$$branch_name" ]; then \
    echo "$(RED)Error: Failed to get branch name for issue #$(ISSUE)$(RESET)"; \
    exit 1; \
fi; \
echo "$(CYAN)Branch name: $$branch_name$(RESET)"; \
gh issue develop $(ISSUE); \
git checkout $$branch_name; \
echo "$(GREEN)Development branch created and checked out: $$branch_name$(RESET)"
```

### After (Fixed)
```makefile
@gh issue develop $(ISSUE) --checkout; \
current_branch=$$(git rev-parse --abbrev-ref HEAD); \
echo "$(GREEN)Development branch created and checked out: $$current_branch$(RESET)"
```

## Validation
- ✅ Makefile syntax validated with `make validate`
- ✅ Command help verified with `gh issue develop --help` 
- ✅ Confirmed `--checkout` flag is supported
- ✅ No breaking changes to existing functionality

## Usage
```bash
make issue-develop ISSUE=123
```

This will now properly create and checkout a development branch for the specified issue without errors.

## Testing
The fix can be tested with:
```bash
make issue-develop ISSUE=222  # This issue itself
```

Fixes #222

🤖 Generated with [Claude Code](https://claude.ai/code)