### PR TITLE
Fix: Add @pytest.mark.slow to timing-based slow tests

### DIFF
--- a/tests/problems/test_problem_043.py
+++ b/tests/problems/test_problem_043.py
@@ -71,6 +71,7 @@ class TestProblem043:
         assert int("728") % 13 == 0
         assert int("289") % 17 == 0
 
+    @pytest.mark.slow
     def test_solve_naive(self) -> None:
         """Test naive solution"""
         result = solve_naive()
@@ -83,12 +84,14 @@ class TestProblem043:
         assert isinstance(result, int)
         assert result > 0  # Should find some valid numbers
 
+    @pytest.mark.slow
     def test_solve_mathematical(self) -> None:
         """Test mathematical solution"""
         result = solve_mathematical()
         assert isinstance(result, int)
         assert result > 0  # Should find some valid numbers
 
+    @pytest.mark.slow
     def test_solutions_agree(self) -> None:
         """Test that all solutions agree (fast algorithms only)"""
         # Only test fast solutions by default

--- a/tests/problems/test_problem_044.py
+++ b/tests/problems/test_problem_044.py
@@ -118,6 +118,7 @@ class TestProblem044:
                 assert recovered_n == n
                 assert generate_pentagonal(recovered_n) == pent
 
+    @pytest.mark.slow
     def test_solve_naive(self) -> None:
         """Test naive solution (optimized for CI)"""
         result = solve_naive()
@@ -126,6 +127,7 @@ class TestProblem044:
         # The result should be a pentagonal number itself
         assert is_pentagonal(result), "The difference should be pentagonal"
 
+    @pytest.mark.slow
     def test_solve_optimized(self) -> None:
         """Test optimized solution"""
         result = solve_optimized()
@@ -134,6 +136,7 @@ class TestProblem044:
         # The result should be a pentagonal number itself
         assert is_pentagonal(result), "The difference should be pentagonal"
 
+    @pytest.mark.slow
     def test_solve_mathematical(self) -> None:
         """Test mathematical solution"""
         result = solve_mathematical()
@@ -142,6 +145,7 @@ class TestProblem044:
         # The result should be a pentagonal number itself
         assert is_pentagonal(result), "The difference should be pentagonal"
 
+    @pytest.mark.slow
     def test_solutions_agree(self) -> None:
         """Test that all solutions agree (fast algorithms only)"""
         # Only test fast solutions by default

--- a/tests/problems/test_problem_051.py
+++ b/tests/problems/test_problem_051.py
@@ -106,6 +106,7 @@ class TestSolutionFunctions:
         result = solver(7)
         assert result == 56003
 
+    @pytest.mark.slow
     def test_solve_consistency(self) -> None:
         """Test that all solution methods give the same result"""
         target_sizes = [6, 7]
@@ -122,6 +123,7 @@ class TestSolutionFunctions:
                 f"Inconsistent results for target {target_size}: {results}"
             )
 
+    @pytest.mark.slow
     def test_solve_main_problem(self) -> None:
         """Test the main problem (8 primes in family)"""
         # Use fast algorithms only for regular tests

--- a/tests/problems/test_problem_052.py
+++ b/tests/problems/test_problem_052.py
@@ -144,6 +144,7 @@ class TestAnalysisFunctions:
         demo_false = demonstrate_permutation_check(123, 124)
         assert demo_false["are_permutations"] is False
 
+    @pytest.mark.slow
     def test_find_smallest_permuted_multiple_family(self) -> None:
         """Test finding smallest permuted multiple families"""
         # Find families of size 2 or more


### PR DESCRIPTION
## Summary

- Add `@pytest.mark.slow` markers to 10 slow tests identified from GitHub Actions timing analysis
- Tests taking 7+ seconds are now properly marked as slow for CI optimization
- Includes tests from problems 043, 044, 051, and 052

## Changes Made

**test_problem_044.py** (4 tests):
- `test_solve_naive` (60.00s) 
- `test_solutions_agree` (23.76s)
- `test_solve_mathematical` (15.39s)
- `test_solve_optimized` (9.13s)

**test_problem_052.py** (1 test):
- `test_find_smallest_permuted_multiple_family` (22.29s)

**test_problem_051.py** (2 tests):
- `test_solve_main_problem` (18.74s)
- `test_solve_consistency` (12.42s)

**test_problem_043.py** (3 tests):
- `test_solutions_agree` (8.02s)
- `test_solve_naive` (7.66s)
- `test_solve_mathematical` (7.13s)

## Test Plan

- [x] Run `make ci-check` locally - all tests pass
- [x] Fast tests now exclude these slow tests (1675 passed, 92 deselected)
- [x] All code quality checks pass (ruff, mypy, bandit)
- [x] Pre-commit hooks pass

## Impact

This will significantly improve CI performance by moving these slow tests to the dedicated slow test suite, reducing fast test execution time while maintaining comprehensive test coverage.

🤖 Generated with [Claude Code](https://claude.ai/code)