### PR TITLE
Align pre-commit and CI mypy configurations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,6 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [types-setuptools, pytest]
-        args: [--ignore-missing-imports, --disable-error-code=misc]
         files: ^(problems|tests)/.*\.py$
 
   - repo: https://github.com/pycqa/bandit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,11 @@ exclude = "problems/runners/"
 module = ["matplotlib.*", "plotly.*"]
 ignore_missing_imports = true
 
+# Ignore optional numerical computation libraries
+[[tool.mypy.overrides]]
+module = ["numpy", "numpy.*"]
+ignore_missing_imports = true
+
 # No additional overrides needed - runners excluded globally
 
 # Pytest configuration


### PR DESCRIPTION
## Summary
- Removed custom mypy arguments from pre-commit config that differed from CI
- Added numpy to mypy ignore list in pyproject.toml
- Both pre-commit and CI now use the same configuration from pyproject.toml

## Problem
Pre-commit was using `--ignore-missing-imports` and `--disable-error-code=misc` flags while CI wasn't, causing different behavior between local development and CI checks.

## Solution
1. Removed the custom args from `.pre-commit-config.yaml`
2. Added numpy to the mypy overrides in `pyproject.toml` (alongside matplotlib and plotly)
3. Now both environments use identical configuration

## Test plan
- [x] Tested pre-commit mypy hook locally - passes
- [x] Tested CI mypy command locally - passes
- [x] Both commands now produce identical results

🤖 Generated with [Claude Code](https://claude.ai/code)